### PR TITLE
fix(krakend): upgrade to version 2 to avoid failure on config read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 example/example
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -4,43 +4,45 @@ The `krakend-martian` package integrates the martian project into the KrakenD fr
 
 ## How to use it
 
-Add your martian DSL definition under the "github.com/krakend-martian/proxy" namespace of the backend section of the config file
+Add your martian DSL definition under the "github.com/devopsfaith/krakend-martian" namespace of the backend section of the config file
 
-	"extra_config": {
-		"github.com/krakend-martian/proxy": {}
-	}
+```
+"extra_config": {
+  "github.com/devopsfaith/krakend-martian": {}
+}
+```
 
 More details here: https://github.com/google/martian#modifiers-all-the-way-down
 
-Check the [example](github.com/krakend-martian/tree/master/example) forlder for a complete demo.
+Check the [example](github.com/krakend-martian/tree/master/example) folder for a complete demo.
 
 ## Example
 
-Build and run the example
+The martian example is built on top of [chuknorris.io](https://api.chucknorris.io/) REST API.
 
-	$ cd example
-	$ go build
-	$ ./example -c krakend.json -d
+* Build and run krakend edition with martian
 
-Send a request to the configured endpoint
+```
+$ cd example
+$ go install ./...
+$ GOPATH/bin/example -c example/krakend.json -d -p 8000
+```
 
-	$ curl -i 127.0.0.1:8080/supu
-	HTTP/1.1 200 OK
-	Cache-Control: public, max-age=0
-	Content-Type: application/json; charset=utf-8
-	X-Krakend: Version undefined
-	Date: Sun, 15 Oct 2017 10:14:20 GMT
-	Content-Length: 18
+* Send a request to the configured endpoint
 
-	{"message":"pong"}
+```
+$ curl -i 127.0.0.1:8000/supu
+ HTTP/1.1 200 OK
+ Cache-Control: public, max-age=0
+ Content-Type: application/json; charset=utf-8
+ X-Krakend: Version undefined
+ X-Krakend-Completed: true
+ Date: Tue, 10 Jul 2018 13:15:04 GMT
+ Content-Length: 80
+
+ {"author":"Chuck Norris","joke":"People pray to God. God prays to Chuck Norris"}
+```
 
 And check the logs of the KrakenD: the request modifiers has done their job!
+See how `"author":"Chuck Norris"` was added to the payload.
 
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU Method: GET
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU URL: /__debug/supu
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU Query: map[]
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU Params: [{param /supu}]
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU Headers: map[X-Martian:[ouh yeah!] Accept-Encoding:[gzip] User-Agent:[KrakenD Version undefined] Content-Length:[19] Content-Type:[application/json] X-Forwarded-For:[127.0.0.1]]
-	[KRAKEND] 2017/10/15 - 12:14:20.871 ▶ DEBU Body: {"msg":"you rock!"}
-	[GIN] 2017/10/15 - 12:14:20 | 200 |     226.159µs |       127.0.0.1 | GET      /__debug/supu
-	[GIN] 2017/10/15 - 12:14:20 | 200 |    2.316784ms |       127.0.0.1 | GET      /supu

--- a/example/krakend.json
+++ b/example/krakend.json
@@ -1,12 +1,12 @@
 {
-    "version": 1,
+    "version": 2,
     "name": "My lovely gateway",
     "port": 8080,
     "cache_ttl": 3600,
     "timeout": "3s",
     "extra_config": {
       "github_com/devopsfaith/krakend-gologging": {
-        "level":  "INFO",
+        "level":  "DEBUG",
         "prefix": "[KRAKEND]",
         "syslog": false,
         "stdout": true
@@ -19,102 +19,25 @@
             "backend": [
                 {
                     "host": [
-                        "http://127.0.0.1:8080"
+                        "https://api.chucknorris.io/"
                     ],
-                    "url_pattern": "/__debug/supu",
+                    "url_pattern": "/jokes/random",
                     "extra_config": {
                         "github.com/devopsfaith/krakend-martian": {
-                            "fifo.Group": {
-                                "scope": ["request", "response"],
-                                "aggregateErrors": true,
-                                "modifiers": [
-                                {
-                                    "header.Modifier": {
-                                        "scope": ["request", "response"],
-                                        "name" : "X-Martian",
-                                        "value" : "ouh yeah!"
-                                    }
-                                },
-                                {
-                                    "body.Modifier": {
-                                        "scope": ["request"],
-                                        "contentType" : "application/json",
-                                        "body" : "eyJtc2ciOiJ5b3Ugcm9jayEifQ=="
-                                    }
-                                },
-                                {
-                                    "header.RegexFilter": {
-                                        "scope": ["request"],
-                                        "header" : "X-Neptunian",
-                                        "regex" : "no!",
-                                        "modifier": {
-                                            "header.Modifier": {
-                                                "scope": ["request"],
-                                                "name" : "X-Martian-New",
-                                                "value" : "some value"
-                                            }
-                                        }
-                                    }
-                                }
-                                ]
+                            "body.Modifier": {
+                                "scope": ["request","response"],
+                                "body": "eyJhdXRob3IiOiJDaHVjayBOb3JyaXMifQ=="
                             }
                         }
                     }
-                }
-            ]
-        },
-        {
-            "endpoint": "/github/{user}",
-            "method": "GET",
-            "backend": [
+                },
                 {
                     "host": [
-                        "https://api.github.com"
+                        "https://api.chucknorris.io/"
                     ],
-                    "url_pattern": "/",
-                    "whitelist": [
-                        "authorizations_url",
-                        "code_search_url"
-                    ],
-                    "disable_host_sanitize": true,
-                    "extra_config": {
-                        "github.com/devopsfaith/krakend-martian": {
-                            "fifo.Group": {
-                                "scope": ["request", "response"],
-                                "aggregateErrors": true,
-                                "modifiers": [
-                                {
-                                    "header.Modifier": {
-                                        "scope": ["request", "response"],
-                                        "name" : "X-Martian",
-                                        "value" : "ouh yeah!"
-                                    }
-                                },
-                                {
-                                    "body.Modifier": {
-                                        "scope": ["request"],
-                                        "contentType" : "application/json",
-                                        "body" : "eyJtc2ciOiJ5b3Ugcm9jayEifQ=="
-                                    }
-                                },
-                                {
-                                    "header.RegexFilter": {
-                                        "scope": ["request"],
-                                        "header" : "X-Neptunian",
-                                        "regex" : "no!",
-                                        "modifier": {
-                                            "header.Modifier": {
-                                                "scope": ["request"],
-                                                "name" : "X-Martian-New",
-                                                "value" : "some value"
-                                            }
-                                        }
-                                    }
-                                }
-                                ]
-                            }
-                        }
-                    }
+                    "url_pattern": "/jokes/random",
+                    "whitelist": [ "value" ],
+                    "mapping": { "value": "joke" }
                 }
             ]
         }


### PR DESCRIPTION
the main fix of this PR is:
- krakend.json version should be 2 to avoid failure in https://github.com/devopsfaith/krakend-martian/blob/master/example/main.go#L26 with `Unsupported version: 1 (want: 2)`
- simply the demo by using test endpoint