### PR TITLE
Expose HTTPRequestExecutor factory wrapper

### DIFF
--- a/martian.go
+++ b/martian.go
@@ -27,6 +27,8 @@ import (
 	_ "github.com/google/martian/status"
 )
 
+type requestExecutorFactory func(*config.Backend) client.HTTPRequestExecutor
+
 // NewBackendFactory creates a proxy.BackendFactory with the martian request executor wrapping the injected one.
 // If there is any problem parsing the extra config data, it just uses the injected request executor.
 func NewBackendFactory(logger logging.Logger, re client.HTTPRequestExecutor) proxy.BackendFactory {
@@ -35,23 +37,31 @@ func NewBackendFactory(logger logging.Logger, re client.HTTPRequestExecutor) pro
 
 // NewConfiguredBackendFactory creates a proxy.BackendFactory with the martian request executor wrapping the injected one.
 // If there is any problem parsing the extra config data, it just uses the injected request executor.
-func NewConfiguredBackendFactory(logger logging.Logger, ref func(*config.Backend) client.HTTPRequestExecutor) proxy.BackendFactory {
-	parse.Register("static.Modifier", staticModifierFromJSON)
-
+func NewConfiguredBackendFactory(logger logging.Logger, ref requestExecutorFactory) proxy.BackendFactory {
+	ref = NewRequestExecutorFactory(logger, ref)
 	return func(remote *config.Backend) proxy.Proxy {
+		return proxy.NewHTTPProxyWithHTTPExecutor(remote, ref(remote), remote.Decoder)
+	}
+}
+
+// NewRequestExecutorFactory creates a request executor factory that takes as input the config.Backend wrapping the injected one.
+// If there is any problem parsing the extra config data, it just uses the injected request executor.
+func NewRequestExecutorFactory(logger logging.Logger, ref requestExecutorFactory) requestExecutorFactory {
+	parse.Register("static.Modifier", staticModifierFromJSON)
+	return func(remote *config.Backend) client.HTTPRequestExecutor {
 		re := ref(remote)
 		result, ok := ConfigGetter(remote.ExtraConfig).(Result)
 		if !ok {
-			return proxy.NewHTTPProxyWithHTTPExecutor(remote, re, remote.Decoder)
+			return re
 		}
 		switch result.Err {
 		case nil:
-			return proxy.NewHTTPProxyWithHTTPExecutor(remote, HTTPRequestExecutor(result.Result, re), remote.Decoder)
+			return HTTPRequestExecutor(result.Result, re)
 		case ErrEmptyValue:
-			return proxy.NewHTTPProxyWithHTTPExecutor(remote, re, remote.Decoder)
+			return re
 		default:
 			logger.Error(result, remote.ExtraConfig)
-			return proxy.NewHTTPProxyWithHTTPExecutor(remote, re, remote.Decoder)
+			return re
 		}
 	}
 }


### PR DESCRIPTION
Hello, I'd like to propose a new interface "lower" than the existing one, which just wraps an `HTTPRequestExecutor` factory
It would allow users to construct their own `proxy.BackendFactory`, thus adds more flexibility

Hope it makes sense!